### PR TITLE
Feat WS3 delete and update images

### DIFF
--- a/app/controllers/tattoos_controller.rb
+++ b/app/controllers/tattoos_controller.rb
@@ -10,7 +10,7 @@ class TattoosController < ApplicationController
   def create
     blob = ActiveStorage::Blob.create_and_upload!(io: params[:img_file], filename: params[:img_file].original_filename)
     tattoo_attributes = {price: params[:price], time_estimate: params[:time_estimate], artist_id: params[:artist_id], image_url: blob.url}
-    
+    require 'pry'; binding.pry
     service = ArtistService.new.send_new_artist_tattoo(tattoo_attributes)
 
     if service[:status] == 200 
@@ -44,8 +44,12 @@ class TattoosController < ApplicationController
   end
 
   def destroy
+    tattoo = ArtistFacade.new.find_tattoo(params[:id])
     ArtistService.new.delete_tattoo(params[:id])
     
+    blob = ActiveStorage::Blob.find_by(key: tattoo.image_url)
+    blob.purge if blob
+
     redirect_to artist_dashboard_path(params[:artist_id])
   end
 end

--- a/app/controllers/tattoos_controller.rb
+++ b/app/controllers/tattoos_controller.rb
@@ -10,7 +10,6 @@ class TattoosController < ApplicationController
   def create
     blob = ActiveStorage::Blob.create_and_upload!(io: params[:img_file], filename: params[:img_file].original_filename)
     tattoo_attributes = {price: params[:price], time_estimate: params[:time_estimate], artist_id: params[:artist_id], image_url: blob.url}
-    require 'pry'; binding.pry
     service = ArtistService.new.send_new_artist_tattoo(tattoo_attributes)
 
     if service[:status] == 200 

--- a/app/views/tattoos/edit.html.erb
+++ b/app/views/tattoos/edit.html.erb
@@ -14,6 +14,9 @@
   <%= f.label :time_estimate %>
   <%= f.text_field :time_estimate, value: @tattoo.time_estimate %> hours<br>
   
+  <%= f.label :image, "Upload New Image" %>
+  <%= f.file_field :img_file %><br>
+  
   <%= f.submit %>
 <% end %>
 

--- a/spec/features/tattoos/edit_spec.rb
+++ b/spec/features/tattoos/edit_spec.rb
@@ -11,9 +11,24 @@ RSpec.describe 'Tattoos Edit Page', type: :feature do
       
       @json_response_2 = File.read("spec/fixtures/artist/tattoo_incorrect.json")
       
-      @json_response_3 = File.read("spec/fixtures/artist/tattoo_2.json")  
+      @json_response_3 = File.read("spec/fixtures/artist/tattoo_2.json")
+
+      @json_response_4 = File.read("spec/fixtures/artist/tat.json")  
+      
       stub_request(:get, "http://localhost:3000/api/v0/tattoos/2")
+        .to_return(status: 200, body: @json_response_4)
+
+      stub_request(:get, "http://localhost:3000/api/v0/tattoos/5")
         .to_return(status: 200, body: @json_response_3)
+
+      stub_request(:patch, "http://localhost:3000/api/v0/tattoos/5")
+        .to_return(status: 200, body: @json_response_3) 
+      
+      stub_request(:get, "http://localhost:3000/api/v0/artists/5/tattoos")
+        .to_return(status: 200, body: @json_response_1)
+
+      allow_any_instance_of(ActiveStorage::Blob).to receive(:url)
+        .and_return("app/assets/images/bronto.jpeg")
     
       visit edit_artist_tattoo_path(artist_id: 5, id: 2)
     end
@@ -39,21 +54,13 @@ RSpec.describe 'Tattoos Edit Page', type: :feature do
     end
 
     describe "the form to edit a new tattoo " do
-      it "has a price and time fields" do
+      it "has a price, time and image_file fields" do
         expect(page).to have_field('Price')
         expect(page).to have_field('Time estimate')
+        expect(page).to have_content('Upload New Image')
       end
 
       it "successfully updates tattoo's price" do   
-        allow_any_instance_of(ActiveStorage::Blob).to receive(:url)
-          .and_return("app/assets/images/bronto.jpeg")
-
-        stub_request(:patch, "http://localhost:3000/api/v0/tattoos/2")
-          .to_return(status: 200, body: @json_response_3)  
-
-        stub_request(:get, "http://localhost:3000/api/v0/artists/5/tattoos")
-          .to_return(status: 200, body: @json_response_1)
-
         fill_in "Price", with: "200"
         click_button "Save"
         expect(current_path).to eq(artist_dashboard_path(artist_id: 5))
@@ -67,12 +74,6 @@ RSpec.describe 'Tattoos Edit Page', type: :feature do
       end
 
       it "successfully updates tattoo's estimated time" do
-        stub_request(:patch, "http://localhost:3000/api/v0/tattoos/2")
-          .to_return(status: 200, body: @json_response_3) 
-        
-        stub_request(:get, "http://localhost:3000/api/v0/artists/5/tattoos")
-          .to_return(status: 200, body: @json_response_1)
-
         fill_in "Time estimate", with: "60"
         click_button "Save"
         expect(current_path).to eq(artist_dashboard_path(artist_id: 5))
@@ -85,16 +86,37 @@ RSpec.describe 'Tattoos Edit Page', type: :feature do
         end
       end
 
+      it "successfully updates tattoo's url locally and in WS3" do
+        old_tattoo = ArtistFacade.new.find_tattoo("2")
+        old_blob = ActiveStorage::Blob.find_by(key: old_tattoo.image_url)
+        
+        attributes = {artist_id: "5", image_url: "app/assets/images/bronto.jpeg", price: "50", time_estimate: "2"}
+        
+        allow_any_instance_of(ArtistService).to receive(:post_url).with("/api/v0/tattoos", attributes)
+          .and_return(status: 200, body: "")
+        
+        attach_file "img_file", 'app/assets/images/bronto.jpeg'
+        click_button "Save"
+
+        new_tattoo = ArtistFacade.new.find_tattoo("5")
+        new_blob = ActiveStorage::Blob.find_by(key: new_tattoo.image_url)
+
+        expect(old_blob).to be(nil)
+      end
+
       it "handles sad path on form fields and sends back to edit form" do
         json_response_0 = File.read("spec/fixtures/artist/tattoo_incorrect.json")
         stub_request(:patch, "http://localhost:3000/api/v0/tattoos/2")
+          .to_return(status: 404, body: json_response_0)
+
+        stub_request(:patch, "http://localhost:3000/api/v0/tattoos/5")
           .to_return(status: 404, body: json_response_0)
 
         fill_in "Price", with: "a"
         fill_in "Time estimate", with: 2
         click_button "Save"
 
-        expect(current_path).to eq(edit_artist_tattoo_path(artist_id: 5, id: 2))
+        expect(current_path).to eq(edit_artist_tattoo_path(artist_id: 5, id: 5))
         expect(page).to have_text("Tattoo could not be updated")
       end
     end

--- a/spec/fixtures/artist/tat.json
+++ b/spec/fixtures/artist/tat.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "5",
+    "type": "tattoo",
+    "attributes": {
+      "image_url": "app/assets/images/bronto.jpeg",
+      "price": 300,
+      "time_estimate": 120,
+      "artist_id": 5
+    }
+  }
+}


### PR DESCRIPTION
## Type of change
- [x] New feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Documentation
- [ ] Other:

## Description
This branch allows an artist to delete and update a tattoo image, updating or deleting the WS3 record as well.

## Issue(s):
closes #41 
closes #42 

## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally
- [x] Unnecessary comments removed
- [ ] Test coverage 100%

## Any Outstanding Issues/Problems?
- [x ] My code is wonderful, no issues here!
- [ ] Yeah, see additional words below
