### PR TITLE
Add caching to dashboard tattoos

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -10,7 +10,7 @@ class ArtistsController < ApplicationController
   end
 
   def create
-    artist = ArtistFacade.create_artist(new_artist_params)
+    artist = ArtistFacade.create_artist(new_artist_params.to_h)
     ArtistFacade.create_artist_identities(artist_identities, artist[:data][:id])
     redirect_to artist_dashboard_path(artist[:data][:id])
   end

--- a/app/controllers/users/dashboard_controller.rb
+++ b/app/controllers/users/dashboard_controller.rb
@@ -3,8 +3,8 @@ class Users::DashboardController < ApplicationController
   def show
     user_id = params[:user_id]
     @user = UserFacade.user_data(user_id)
-    Rails.cache.fetch("#{cache_key_with_version(@user)}/dashboard_tattoos", expires_in: 10.minutes) do
-      @tattoos = UserFacade.dashboard_tattoos(user_id)
+    @tattoos = Rails.cache.fetch("#{user_id}/dashboard-tattoos", expires_in: 10.minutes) do
+      UserFacade.dashboard_tattoos(user_id)
     end
     render 'users/dashboard'
   end

--- a/app/controllers/users/dashboard_controller.rb
+++ b/app/controllers/users/dashboard_controller.rb
@@ -3,7 +3,7 @@ class Users::DashboardController < ApplicationController
   def show
     user_id = params[:user_id]
     @user = UserFacade.user_data(user_id)
-    @tattoos = Rails.cache.fetch("#{user_id}/dashboard-tattoos", expires_in: 10.minutes) do
+    @tattoos = Rails.cache.fetch("#{cache_key_with_version(@user)}-dashboard-tattoos", expires_in: 10.minutes) do
       UserFacade.dashboard_tattoos(user_id)
     end
     render 'users/dashboard'

--- a/app/controllers/users/dashboard_controller.rb
+++ b/app/controllers/users/dashboard_controller.rb
@@ -1,8 +1,11 @@
 class Users::DashboardController < ApplicationController
+  include ApplicationHelper
   def show
     user_id = params[:user_id]
     @user = UserFacade.user_data(user_id)
-    @tattoos = UserFacade.dashboard_tattoos(user_id)
+    Rails.cache.fetch("#{cache_key_with_version(@user)}/dashboard_tattoos", expires_in: 10.minutes) do
+      @tattoos = UserFacade.dashboard_tattoos(user_id)
+    end
     render 'users/dashboard'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -54,7 +54,7 @@ class UsersController < ApplicationController
 
   def user_identities_updated?
     params.permit(:original_user_identities, :identities, "original_user_identities", "identities")
-    @original_identities = params[:original_user_identities].split
+    @original_identities = params[:original_user_identities].split if params[:original_user_identities]
     @updated_identities = params[:identities]
 
     @updated_identities != @original_identities

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,8 @@
 module ApplicationHelper
-  def cache_key_with_version(model_class, label = "")
-    prefix = model_class.to_s.downcase.pluralize
+  def cache_key_with_version(model_class)
+    location = model_class.location
     id = model_class.id
-    [prefix, label, id].join("-")
+    search_radius = model_class.search_radius
+    [location, search_radius, id].join("-")
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+  def cache_key_with_version(model_class, label = "")
+    prefix = model_class.to_s.downcase.pluralize
+    id = model_class.id
+    [prefix, label, id].join("-")
+  end
 end

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -5,19 +5,20 @@
 <%= render partial: "shared/nav_user"%>
 
 <section>
-<%= form_with url: user_path(id: @user.id), local: true, data: {turbo: false} do |form|%>
+<%= form_with url: user_path(id: @user.id), method: :patch, data: {turbo: false} do |form|%>
   <%= form.label :location, "Current Location" %>
   <%= form.text_field :location, value: @user.location, size: 50  %>
   <%= form.submit "Update" %>
 <% end %>
 
-<%= form_with url: user_path(id: @user.id), local: true, data: {turbo: false} do |form|%>
+<%= form_with url: user_path(id: @user.id), method: :patch, local: true, data: {turbo: false} do |form|%>
   <%= form.label :search_radius, "Search Radius" %>
   <%= form.text_field :search_radius, value: @user.search_radius %>
   <%= form.submit "Update"%>
 <% end %>
 </section>
-<% cache("#{@user.id}/dashboard-tattoos") do %>
+
+<% cache("#{@user.location}-#{@user.search_radius}-#{@user.id}-dashboard-tattoos") do %>
 <section class="user_dashboard_tattoos">
   <% @tattoos.each do |tattoo| %>
     <div class="tattoo_option" >

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -17,7 +17,7 @@
   <%= form.submit "Update"%>
 <% end %>
 </section>
-
+<% cache("#{@user.id}/dashboard-tattoos") do %>
 <section class="user_dashboard_tattoos">
   <% @tattoos.each do |tattoo| %>
     <div class="tattoo_option" >
@@ -47,6 +47,7 @@
     </div>
   <% end %>
 </section>
+<% end %>
 
 
 <%= button_to 'Sign Out', sign_out_path, method: :delete %>

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -48,6 +48,7 @@
   <% end %>
 </section>
 
+
 <%= button_to 'Sign Out', sign_out_path, method: :delete %>
 
 <style>


### PR DESCRIPTION
## Type of change
- [x] New feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Documentation
- [ ] Other:

## Description
Relevant User Story(s): 
This branch adds the following functionality:
- Caching feature for UserDashboard for all dashboard tattoos
- Cache expires after 10 minutes currently or when user changes their location/search radius


## Issue(s):
closes #48 

## Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally
- [x] Unnecessary comments removed
- [ ] Test coverage 100%
